### PR TITLE
lsコマンドプログラム - 3

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -7,8 +7,7 @@ COLUMN = 3
 
 def main
   options = parse_options
-  flags = options[:a] ? File::FNM_DOTMATCH : 0
-  filenames = Dir.glob('*', flags)
+  filenames = options[:r] ? Dir.glob('*').reverse : Dir.glob('*')
   print_columns_format(filenames)
 end
 
@@ -16,6 +15,7 @@ def parse_options
   options = {}
   OptionParser.new do |opt|
     opt.on('-a', 'Include hidden files') { |a| options[:a] = a }
+    opt.on('-r', 'Reverse the order of the sort') { |r| options[:r] = r }
     opt.parse!(ARGV)
   end
   options


### PR DESCRIPTION
- [lsコマンドを作る | FBC](https://bootcamp.fjord.jp/pages/ls-command#requirements)
- [lsコマンドを作る3 | FBC](https://bootcamp.fjord.jp/practices/223)

parse_optionsメソッドに-aオプション用のコードが残っていますが、最終的にまたそのまま戻すことになると思われたため、カットはしていません。