### PR TITLE
lsコマンドプログラム - 5

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -35,7 +35,8 @@ def current_directory_contents(options = {})
 end
 
 def print_long_format(contents)
-  puts "total #{calculate_total_blocks}"
+  total_blocks = contents.sum { |item| File.stat(item).blocks }
+  puts "total #{total_blocks}"
 
   contents.each do |item|
     file_stat = File.stat(item)
@@ -48,14 +49,6 @@ def print_long_format(contents)
     print " #{file_stat.mtime.strftime('%_m %e %H:%M')}"
     puts " #{item}"
   end
-end
-
-def calculate_total_blocks
-  total_blocks = 0
-  current_directory_contents.each do |item|
-    total_blocks += File.stat(item).blocks
-  end
-  total_blocks
 end
 
 def print_permissions(file_stat)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -58,8 +58,8 @@ def print_stats(stats)
   end
 end
 
-def print_permissions(file_stat)
-  mode = file_stat.mode
+def print_permissions(stat)
+  mode = stat.mode
   print_permissions_for_user_type(mode >> 6)
   print_permissions_for_user_type(mode >> 3)
   print_permissions_for_user_type(mode)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -13,7 +13,7 @@ FILE_TYPE_MAP = {
 
 def main
   options = parse_options
-  contents = current_directory_contents
+  contents = current_directory_contents(options)
   options[:l] ? print_long_format(contents) : print_columns_format(contents)
 end
 
@@ -28,8 +28,10 @@ def parse_options
   options
 end
 
-def current_directory_contents
-  Dir.glob('*')
+def current_directory_contents(options = {})
+  flags = options[:a] ? File::FNM_DOTMATCH : 0
+  contents = Dir.glob('*', flags)
+  options[:r] ? contents.reverse : contents
 end
 
 def print_long_format(contents)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -28,7 +28,7 @@ def parse_options
   options
 end
 
-def current_directory_contents(options = {})
+def current_directory_contents(options)
   flags = options[:a] ? File::FNM_DOTMATCH : 0
   contents = Dir.glob('*', flags)
   options[:r] ? contents.reverse : contents

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -35,18 +35,25 @@ def current_directory_contents(options = {})
 end
 
 def print_long_format(contents)
-  total_blocks = contents.sum { |item| File.stat(item).blocks }
-  puts "total #{total_blocks}"
+  stats = contents.map { |item| [item, File.stat(item)] }.to_h
+  print_total_blocks(contents, stats)
+  print_stats(stats)
+end
 
-  contents.each do |item|
-    file_stat = File.stat(item)
-    print FILE_TYPE_MAP.fetch(file_stat.ftype, '?')
-    print_permissions(file_stat)
-    print " #{file_stat.nlink.to_s.rjust(3)}"
-    print " #{Etc.getpwuid(file_stat.uid).name}"
-    print " #{Etc.getgrgid(file_stat.gid).name}"
-    print " #{file_stat.size.to_s.rjust(5)}"
-    print " #{file_stat.mtime.strftime('%_m %e %H:%M')}"
+def print_total_blocks(contents, stats)
+  total_blocks = contents.sum { |item| stats[item].blocks }
+  puts "total #{total_blocks}"
+end
+
+def print_stats(stats)
+  stats.each do |item, stat|
+    print FILE_TYPE_MAP.fetch(stat.ftype, '?')
+    print_permissions(stat)
+    print " #{stat.nlink.to_s.rjust(3)}"
+    print " #{Etc.getpwuid(stat.uid).name}"
+    print " #{Etc.getgrgid(stat.gid).name}"
+    print " #{stat.size.to_s.rjust(5)}"
+    print " #{stat.mtime.strftime('%_m %e %H:%M')}"
     puts " #{item}"
   end
 end


### PR DESCRIPTION
- [lsコマンドを作る | FBC](https://bootcamp.fjord.jp/pages/ls-command#requirements)
- [ls コマンドを作る5 | FBC](https://bootcamp.fjord.jp/practices/160)

ls-2, ls-3の内容をls-4に統合したのち、`print_long_format`メソッドが少し重くなったので別メソッドに切り出すなど、ls-4の段階から少し手を加えています。